### PR TITLE
Move logic from tableView to Section

### DIFF
--- a/Organic/Source/OrganicSection.h
+++ b/Organic/Source/OrganicSection.h
@@ -33,6 +33,8 @@ typedef void (^CellActionBlock)(NSInteger row);
 @property (nonatomic, copy, readonly) CellForRowBlock cellForRowBlock;
 @property (nonatomic, copy, readonly) CellActionBlock reusedCellActionBlock;
 
+- (CGFloat)cellHeightForRow:(NSInteger)row inTableView:(UITableView *)tableView;
+- (UITableViewCell *)cellForRow:(NSInteger)row inTableView:(UITableView *)tableView;
 
 #pragma mark - Convenience initializers without reuse
 

--- a/Organic/Source/OrganicSection.m
+++ b/Organic/Source/OrganicSection.m
@@ -7,6 +7,7 @@
 //
 
 #import "OrganicSection.h"
+#import "OrganicCell.h"
 
 @implementation OrganicSection
 
@@ -74,6 +75,30 @@
     section.footerHeight = footerHeight;
     section.cells = [cells mutableCopy];
     return section;
+}
+
+
+#pragma mark - TableView delegate methods
+
+- (CGFloat)cellHeightForRow:(NSInteger)row inTableView:(UITableView *)tableView
+{
+    if (self.reuseEnabled) {
+        return self.reusedCellHeight;
+    }
+    else {
+        OrganicCell *cell = self.cells[row];
+        return cell.height;
+    }
+}
+
+- (UITableViewCell *)cellForRow:(NSInteger)row inTableView:(UITableView *)tableView
+{
+    if (self.reuseEnabled) {
+        return self.cellForRowBlock(tableView, row);
+    }
+    else {
+        return self.cells[row];
+    }
 }
 
 

--- a/Organic/Source/OrganicViewController.m
+++ b/Organic/Source/OrganicViewController.m
@@ -65,27 +65,12 @@
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
     OrganicSection *organicSection = self.sections[indexPath.section];
-    
-    if (organicSection.reuseEnabled) {
-        return organicSection.reusedCellHeight;
-    }
-    
-    else {
-        OrganicCell *cell = organicSection.cells[indexPath.row];
-        return cell.height;
-    }
+    return [organicSection cellHeightForRow:indexPath.row inTableView:tableView];
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     OrganicSection *organicSection = self.sections[indexPath.section];
-    
-    if (organicSection.reuseEnabled) {
-        return organicSection.cellForRowBlock(tableView, indexPath.row);
-    }
-    
-    else {
-        return organicSection.cells[indexPath.row];
-    }
+    return [organicSection cellForRow:indexPath.row inTableView:tableView];
 }
 
 


### PR DESCRIPTION
This allows to create custom smart OrganicSections, for example DynamicHeightReuseOrganicSection:

```
- (CGFloat)cellHeightForRow:(NSInteger)row inTableView:(UITableView *)tableView
{
    if (self.reuseEnabled) {
        OrganicCell *cell = [self cellForRow:row inTableView:tableView];
        [cell layoutIfNeeded];
        return cell.height;
    }
    else {
        [super cellHeightForRow:row inTableView:tableView];
    }
}
```
